### PR TITLE
Arreglo botones en dispositivos pequeños.

### DIFF
--- a/client-participation/css/conversationView.scss
+++ b/client-participation/css/conversationView.scss
@@ -869,9 +869,18 @@ svg {
   #loginButtonInTabsBar {
     font-size: 14px !important; // !important since there are inline styles
   }
-
+  .reactionButton{
+	width: 30%;
+	font-size: 9pt;
+  }
 }
 
+@media (max-width: 330px) {
+
+  .reactionButton{
+	font-size: 8pt;
+  }
+}
 
 
 /* Everything but mobile */


### PR DESCRIPTION
Se arregló el tamaño para que el texto "desacuerdo" no quede más grande que el botón.